### PR TITLE
pass through more mon options from the conf file

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ exports.parseConfig = function(str){
       case 'pids':
       case 'on-error':
       case 'on-restart':
+      case 'sleep':
+      case 'attempts':
+      case 'prefix':
         conf[key] = val;
         break;
       default:

--- a/lib/process.js
+++ b/lib/process.js
@@ -31,6 +31,9 @@ function Process(group, name, cmd) {
   this.group = group;
   this.onerror = conf['on-error'];
   this.onrestart = conf['on-restart'];
+  this.sleep = conf.sleep;
+  this.attempts = conf.attempts;
+  this.prefix = conf.prefix;
   this.logfile = join(conf.logs, name + '.log');
   this.pidfile = join(conf.pids, name + '.pid');
   this.monpidfile = this.pidfile.replace('.pid', '.mon.pid');
@@ -153,6 +156,9 @@ Process.prototype.start = function(fn){
 
   if (this.onerror) cmd.push('--on-error "' + this.onerror + ' ' + this.name + '"');
   if (this.onrestart) cmd.push('--on-restart "' + this.onrestart + ' ' + this.name + '"');
+  if (this.sleep) cmd.push('--sleep ' + this.sleep);
+  if (this.attempts) cmd.push('--attempts ' + this.attempts);
+  if (this.prefix) cmd.push('--prefix ' + this.prefix);
 
   cmd.push('"' + this.cmd + '"');
   cmd = cmd.join(' ');


### PR DESCRIPTION
this enables three new options in the conf file, e.g.

```
sleep = 10
prefix = "log prefix"
attempts = 5
```
