### PR TITLE
add option to specify in mon bin path in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ exports.parseConfig = function(str){
       case 'sleep':
       case 'attempts':
       case 'prefix':
+      case 'mon':
         conf[key] = val;
         break;
       default:

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ exports.parseConfig = function(str){
       case 'attempts':
       case 'prefix':
       case 'mon':
+      case 'exec':
         conf[key] = val;
         break;
       default:

--- a/lib/group.js
+++ b/lib/group.js
@@ -6,6 +6,7 @@
 var Emitter = require('events').EventEmitter;
 var Process = require('./process');
 var Batch = require('batch');
+var debug = require('debug')('mongroup:group');
 
 /**
  * Expose `Group`.
@@ -73,10 +74,14 @@ Group.prototype.start = function(names, fn){
 
   this.find(names).forEach(function(proc){
     batch.push(function(done){
-      if (proc.alive()) return done();
+      if (proc.alive()) {
+        debug('start %s (was already alive)', proc.name);
+        return done();
+      }
       proc.start(function(err){
         if (err) return done(err);
         self.emit('start', proc);
+        debug('started %s', proc.name);
         done();
       });
     });
@@ -100,11 +105,15 @@ Group.prototype.stop = function(names, sig, fn){
 
   this.find(names).forEach(function(proc){
     batch.push(function(done){
-      if (!proc.alive()) return done();
+      if (!proc.alive()) {
+        debug('stop %s (was not alive)', proc.name);
+        return done();
+      }
       self.emit('stopping', proc);
       proc.stop(sig, function(err){
         if (err) return done(err);
         self.emit('stop', proc);
+        debug('stopped %s', proc.name);
         done();
       });
     });

--- a/lib/process.js
+++ b/lib/process.js
@@ -32,6 +32,7 @@ function Process(group, name, cmd) {
   this.onerror = conf['on-error'];
   this.onrestart = conf['on-restart'];
   this.mon = conf.mon || 'mon';
+  this.exec = conf.exec || {};
   this.sleep = conf.sleep;
   this.attempts = conf.attempts;
   this.prefix = conf.prefix;
@@ -163,8 +164,8 @@ Process.prototype.start = function(fn){
 
   cmd.push('"' + this.cmd + '"');
   cmd = cmd.join(' ');
-  debug('exec `%s`', cmd);
-  var proc = exec(cmd, fn);
+  debug('exec `%s`', cmd, this.exec);
+  var proc = exec(cmd, this.exec, fn);
 };
 
 /**

--- a/lib/process.js
+++ b/lib/process.js
@@ -194,7 +194,11 @@ Process.prototype.pollExit = function(fn){
   setTimeout(function(){
     if (self.monalive()) return self.pollExit(fn);
     debug('poll %s for exit', self.name);
-    self.removePidfiles();
+    try {
+      self.removePidfiles();
+    } catch (err) {
+      return fn(err);
+    }
     fn();
   }, 500);
 };

--- a/lib/process.js
+++ b/lib/process.js
@@ -31,6 +31,7 @@ function Process(group, name, cmd) {
   this.group = group;
   this.onerror = conf['on-error'];
   this.onrestart = conf['on-restart'];
+  this.mon = conf.mon || 'mon';
   this.sleep = conf.sleep;
   this.attempts = conf.attempts;
   this.prefix = conf.prefix;
@@ -148,7 +149,7 @@ Process.prototype.monalive = function(){
 
 Process.prototype.start = function(fn){
   var self = this;
-  var cmd = ['mon'];
+  var cmd = [this.mon];
   cmd.push('-d');
   cmd.push('-l ' + this.logfile);
   cmd.push('-p ' + this.pidfile);

--- a/lib/process.js
+++ b/lib/process.js
@@ -152,9 +152,9 @@ Process.prototype.start = function(fn){
   var self = this;
   var cmd = [this.mon];
   cmd.push('-d');
-  cmd.push('-l ' + this.logfile);
-  cmd.push('-p ' + this.pidfile);
-  cmd.push('-m ' + this.monpidfile);
+  cmd.push('-l "' + this.logfile + '"');
+  cmd.push('-p "' + this.pidfile + '"');
+  cmd.push('-m "' + this.monpidfile + '"');
 
   if (this.onerror) cmd.push('--on-error "' + this.onerror + ' ' + this.name + '"');
   if (this.onrestart) cmd.push('--on-restart "' + this.onrestart + ' ' + this.name + '"');


### PR DESCRIPTION
i wanna embed mongroup in an app with it's own local `mon` bin, so this lets you put `mon = ./mon` in your config and mongroup will use that mon, otherwise it will default to `spawn('mon')` like normal
